### PR TITLE
SIDM-9403 Dockerfile user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ ARG PLATFORM=""
 
 FROM hmctspublic.azurecr.io/base/java${PLATFORM}:21-distroless
 
+USER hmcts
+LABEL maintainer="https://github.com/hmcts/idam-user-profile-bridge"
+
 ADD --chown=hmcts:hmcts build/libs/idam-user-profile-bridge.jar \
                         lib/applicationinsights.json /opt/app/
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SIDM-9403

### Change description

Add USER in Dockerfile as per fortify rules - although idam-api comments indicate that hmcts is the default user in the distro anyway, but how could fortify know that.

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
